### PR TITLE
Fix: Avoid infinite loop if SQL ends with number

### DIFF
--- a/src/squelch/lex.d
+++ b/src/squelch/lex.d
@@ -306,7 +306,7 @@ tokenLoop:
 			return q.length && isDigit(q[0]);
 		}())
 		{
-			auto text = s.skipWhile!((char c) => c.isOneOf("0123456789abcdefABCDEFxX-."));
+			auto text = s.skipWhile!((char c) => c.isOneOf("0123456789abcdefABCDEFxX-."))(true);
 			tokens ~= Token(TokenNumber(text.toLower));
 			continue tokenLoop;
 		}


### PR DESCRIPTION
If the SQL file ends in a number, squelch can get into an infinite loop. [example.txt](https://github.com/CyberShadow/squelch/files/14950752/example.txt) (without newline at the end)

```sql
SELECT
  *
FROM
  t
QUALIFY
  ROW_NUMBER() OVER () = 1
```