### PR TITLE
Additional operators

### DIFF
--- a/src/squelch/lex.d
+++ b/src/squelch/lex.d
@@ -35,6 +35,8 @@ immutable string[] operators =
 	"~",
 	"<<", ">>",
 	"=>",
+  // duckdb special operator in UNNEST(col, recursive := true)
+  ":="
 ];
 
 // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords
@@ -360,29 +362,40 @@ tokenLoop:
 			continue tokenLoop;
 		}
 
-		// TokenOperator
-		foreach_reverse (operator; operators)
-			if (s.startsWith(operator))
-			{
-				s = s[operator.length .. $];
+    // TokenOperator
+    foreach_reverse (operator; operators)
+        if (s.startsWith(operator))
+        {
+            s = s[operator.length .. $];
 
-				// Normalize operators
-				string token = {
-					switch (operator)
-					{
-						case "<>":
-							return "!=";
-						default:
-							return operator;
-					}
-				}();
+            // Normalize operators
+            string token = {
+                switch (operator)
+                {
+                case "<>":
+                    return "!=";
+                case ":=":
+                    if (dialect != Dialect.duckdb)
+                    {
+                        throw new Exception(
+                                "Unrecognized syntax ':=' for dialect " ~ dialect.to!string ~ ": " ~ s[0 .. min(20,
+                                $)]); // Error if not DuckDB
+                    }
+                    else
+                    {
+                        goto default;
+                    }
+                default:
+                    return operator;
+                }
+            }();
 
-				tokens ~= Token(TokenOperator(token));
-				continue tokenLoop;
-			}
+            tokens ~= Token(TokenOperator(token));
+            continue tokenLoop;
+        }
 
-		throw new Exception("Unrecognized syntax: " ~ s[0..min(20, $)]);
-	}
+    throw new Exception("Unrecognized syntax: " ~ s[0 .. min(20, $)]);
+    }
 
 	// Process contextual keywords
 

--- a/src/squelch/lex.d
+++ b/src/squelch/lex.d
@@ -36,7 +36,8 @@ immutable string[] operators =
 	"<<", ">>",
 	"=>",
   // duckdb special operator in UNNEST(col, recursive := true)
-  ":="
+  ":=",
+  "**"
 ];
 
 // https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords

--- a/test/duckdb/issue8.sql
+++ b/test/duckdb/issue8.sql
@@ -1,0 +1,14 @@
+-- assignment operator := in recursive unnest
+SELECT
+  UNNEST(kpis, RECURSIVE := TRUE),
+  col1
+FROM
+  table;
+
+-- exponent operator **
+SELECT
+  1 - wresiduals_sq / (wlabels_sq - wlabels ** 2 / w) AS r2,
+FROM
+  table
+WHERE
+  wresiduals_sq IS NOT NULL;


### PR DESCRIPTION
Hello @CyberShadow 

This is my first time contributing and looking at the d code for squelch. Working with the new dialect option for DuckDb, I have encountered some lexing issue parsing some special operators

- Adding the walrus operator `:=` to the list of operators, the lexer can correctly parse expressions like 


```SQL
    SELECT
      UNNEST(kpis, recursive := true),
      * EXCLUDE(kpis),
    FROM
      'table'
```

Although the recursive and true are upper case as keywords, I suppose?

giving me 

```SQL
    SELECT
      UNNEST(kpis, RECURSIVE := TRUE),
      * EXCLUDE(kpis),
    FROM
      'table'
```

which ddb does not really care about really when running the queries. I am able to compile a ddb query passing `--dialect=duckdb` 


I also encountered an issue trying to correctly format the exponent operator https://duckdb.org/docs/sql/functions/numeric `**` which is parsed as `* *` single multiplications. Which is also an alias of just `^`


I do not have any tests. Could you give me a hint on how to add a test here?


Thanks!


